### PR TITLE
Update traning.py

### DIFF
--- a/qbm_quimb/training.py
+++ b/qbm_quimb/training.py
@@ -9,26 +9,30 @@ from qbm_quimb import hamiltonians
 
 
 class GibbsState:
-    def __init__(self, ham_ops: list[qu.qarray], coeffs: np.ndarray[float], beta: float):
+    """Parent class to represent a Gibbs state."""
+
+    def __init__(
+        self, ham_ops: list[qu.qarray], coeffs: np.ndarray[float], beta: float
+    ):
         self.ham_ops = ham_ops
         self.coeffs = coeffs
         self.beta = beta
-        
+
     def get_hamiltonian(self) -> qu.qarray:
         """Return total QBM Hamiltonian."""
         return hamiltonians.total_hamiltonian(self.ham_ops, self.coeffs)
-    
+
     def get_coeffs(self) -> np.ndarray[float]:
         """Return a list of coefficients."""
         return self.coeffs
-        
+
     def get_density_matrix(self) -> qu.qarray:
         """Return the density matrix of Gibbs state."""
         ham = self.get_hamiltonian()
         return qu.thermal_state(ham, self.beta)
-    
+
     def compute_expectation(self, ops: list[qu.qarray]) -> list[float]:
-        """Compute expectation valus of a set of operators w.r.t the Gibbs state.
+        """Compute expectation values of a set of operators w.r.t the Gibbs state.
 
         Args:
             ops (float[qu.qarray]): A list of operators.
@@ -36,17 +40,16 @@ class GibbsState:
         Returns:
             list[float]: A list of expectation values.
         """
-        expectations = []
         rho = self.get_density_matrix()
-        for op in ops:
-            expectations.append(qu.expec(rho, op))
-        return expectations
-    
-    
+        return [qu.expec(rho, op) for op in ops]
+
+
 class QBM(GibbsState):
+    """Represent a quantum Boltzmann machine exp(H) for a model Hamiltonian H."""
+
     def __init__(self, ham_ops: list[qu.qarray], coeffs: list[float]):
-        super().__init__(ham_ops, coeffs, beta = -1.0)
-        
+        super().__init__(ham_ops, coeffs, beta=-1.0)
+
     def compute_grads(self, target_expects: list[float]) -> np.ndarray[float]:
         """Compute gradient of operator expectation values.
 
@@ -59,7 +62,7 @@ class QBM(GibbsState):
         qbm_expects = self.compute_expectation(self.ham_ops)
         grads = [qbm - targ for (qbm, targ) in zip(qbm_expects, target_expects)]
         return np.array(grads)
-    
+
     def update_params(self, grads: np.ndarray[float], learning_rate: float) -> None:
         """Update coefficients of Hamiltonian in QBM.
 
@@ -68,7 +71,7 @@ class QBM(GibbsState):
             learning_rate (float): A learning rate.
         """
         self.coeffs = self.coeffs - learning_rate * grads
-        
+
     def compute_qre(self, target_state: GibbsState) -> float:
         """Compute quantum relative entropy between target (eta) and QBM states (rho),
         Tr[eta ln(eta) - eta ln(rho)].
@@ -79,26 +82,30 @@ class QBM(GibbsState):
         Returns:
             float: Quantum relative entropy.
         """
-        # h = qu.entropy(eta) # do not use because it has log2 inside
-        # use log base e all the way
         eta = target_state.get_density_matrix()
-        eta_evals = qu.eigvalsh(eta).clip(1e-300)
-        h = np.sum(eta_evals * np.log(eta_evals))
+        # check if rank = 1, i.e., eta is a pure state
+        if np.linalg.matrix_rank(eta.A) == 1:
+            h = 0
+        else:
+            # h = qu.entropy(eta) # do not use because it has log2 inside
+            # use log base e all the way
+            eta_evals = qu.eigvalsh(eta).clip(1e-300)
+            h = np.sum(eta_evals * np.log(eta_evals))
         ham = self.get_hamiltonian()
         ham_evals = qu.eigvalsh(ham).clip(1e-300)
         z = np.sum(np.exp(ham_evals))
-        eta_expects = qu.expec(eta, ham)
-        return h - eta_expects + qu.log(z)
+        eta_stat = qu.expec(eta, ham)
+        return h - eta_stat + qu.log(z)
 
 
 def train_qbm(
     qbm: QBM,
     target_expects: list[float],
-    learning_rate: float=0.2,
-    epochs: int=200,
-    eps: float=1e-6,
-    compute_qre: bool=False,
-    target_eta: Optional[GibbsState]=None
+    learning_rate: float = 0.2,
+    epochs: int = 200,
+    eps: float = 1e-6,
+    compute_qre: bool = False,
+    target_eta: Optional[GibbsState] = None,
 ) -> tuple[QBM, list[np.ndarray], list[float]]:
     """Training QBM given a list of target expectation values.
 

--- a/script/benchmark.py
+++ b/script/benchmark.py
@@ -22,7 +22,9 @@ parser.add_argument(
     "--e", type=int, default=200, help="Number of traninig epochs (200)"
 )
 parser.add_argument("--er", type=int, default=1e-6, help="Error tolerance (1e-6)")
-parser.add_argument("--qre", type=bool, default=True, help="True to output relative entropies")
+parser.add_argument(
+    "--qre", type=bool, default=True, help="True to output relative entropies"
+)
 
 args = parser.parse_args()
 
@@ -73,7 +75,7 @@ qbm_state, max_grads_hist, qre_hist = training.train_qbm(
     epochs=epochs,
     eps=eps,
     compute_qre=compute_qre,
-    target_eta=target_eta
+    target_eta=target_eta,
 )
 
 


### PR DESCRIPTION
Following Matthias' suggestion, I have added a QBM class in training.py. Now, one can train a QBM given a set of target expectation values using qbm_traininig. This optionally takes a target GibbsState to keep track of relative entropy during training. In script/benchmark.py, I still compute the target expectation values, but this will be replaced with data import once we have implemented data.py.